### PR TITLE
Changed TOTP QR Code to correct format

### DIFF
--- a/Resources/Views/user.leaf
+++ b/Resources/Views/user.leaf
@@ -2,7 +2,7 @@
 #set("scripts") {
     <script type="text/javascript" src="/vendors/js/qrcode.js"></script>
     <script>
-        jQuery('#code').qrcode("#(totpToken)");
+        jQuery('#code').qrcode("otpauth://totp/Fax%20Server:#(email)?secret=#(totpToken)&issuer=Fax%20Server&algorithm=SHA1&digits=6&period=30");
     </script>
 }
 #set("main") {


### PR DESCRIPTION
Fixes https://github.com/bludesign/FaxServer/issues/9 by making the QR code contain not only the secret but also the meta data necessary for common authenticator apps to add an entry.