### PR TITLE
Fix TOTP code generation

### DIFF
--- a/Resources/Views/user.leaf
+++ b/Resources/Views/user.leaf
@@ -2,7 +2,7 @@
 #set("scripts") {
     <script type="text/javascript" src="/vendors/js/qrcode.js"></script>
     <script>
-        jQuery('#code').qrcode("#(totpToken)");
+        jQuery('#code').qrcode("otpauth://totp/Fax%20Server:#(email)?secret=#(totpToken)&issuer=Fax%20Server&algorithm=SHA1&digits=6&period=30");
     </script>
 }
 #set("main") {


### PR DESCRIPTION
Generate proper QR codes for 2FA that are readable by apps such as Google Authenticator.

This is a repeat of https://github.com/bludesign/FaxServer/pull/10 to conform to the otpauth protocol:

"otpauth://TYPE/LABEL?PARAMETERS"